### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -14,8 +14,8 @@ MCP23017	KEYWORD1
 
 begin	KEYWORD2
 configure	KEYWORD2
-setGPIO KEYWORD2
-buttonRead KEYWORD2
+setGPIO	KEYWORD2
+buttonRead	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords